### PR TITLE
Fix component import path normalization bug

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -1,8 +1,5 @@
 use kuchiki::{ElementData, NodeDataRef, NodeRef};
-use std::{
-  collections::BTreeMap,
-  path::{Component, Path, PathBuf},
-};
+use std::path::Path;
 
 pub fn component_replace(
   component_name: &str,
@@ -37,73 +34,52 @@ pub fn component_replace(
   (css, js)
 }
 
-pub fn get_imported_component_paths(html: &NodeRef) -> BTreeMap<String, String> {
-  let mut imported_components = BTreeMap::<String, String>::new();
-
+pub fn get_imported_component_paths(
+  html: &NodeRef,
+  imported_components: &mut Vec<String>,
+  component_base_path: &str,
+) {
   for child in html.inclusive_descendants() {
     if let Some(comment) = child.into_comment_ref() {
       let mut comment_string = comment.as_node().to_string();
+
       if comment_string.contains("import") {
-        comment_string = comment_string.strip_prefix("<!--").unwrap().to_string();
-        comment_string = comment_string.strip_suffix("-->").unwrap().to_string();
+        comment_string = comment_string
+          .strip_prefix("<!--")
+          .unwrap()
+          .to_string()
+          .strip_suffix("-->")
+          .unwrap()
+          .to_string();
+
         let imports: Vec<&str> = comment_string.split("\n").collect();
+
         for import in imports {
           let mut import_string = import.to_string();
+
           if import_string.contains("import") {
             remove_whitespace(&mut import_string);
-            let imported_component_path = import_string
+
+            import_string = import_string
               .strip_prefix("import")
               .unwrap()
               .to_string()
               .replace("'", "");
-            let imported_component_path = normalize_path(Path::new(&imported_component_path));
-            let imported_component_tag_name = Path::new(&imported_component_path)
-              .file_stem()
-              .unwrap()
-              .to_str()
-              .unwrap()
-              .to_string();
-            imported_components.insert(
-              imported_component_tag_name,
-              imported_component_path.to_str().unwrap().to_string(),
-            );
+
+            import_string = format!("{}/{}", component_base_path, import_string);
+
+            let imported_component_path = Path::new(&import_string).canonicalize().unwrap();
+            let imported_component_path = String::from(imported_component_path.to_str().unwrap());
+
+            imported_components.push(imported_component_path);
           }
         }
       }
       comment.as_node().detach();
     }
   }
-
-  imported_components
 }
 
 fn remove_whitespace(s: &mut String) {
   s.retain(|c| !c.is_whitespace());
-}
-
-pub fn normalize_path(path: &Path) -> PathBuf {
-  let mut components = path.components().peekable();
-  let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-    components.next();
-    PathBuf::from(c.as_os_str())
-  } else {
-    PathBuf::new()
-  };
-
-  for component in components {
-    match component {
-      Component::Prefix(..) => unreachable!(),
-      Component::RootDir => {
-        ret.push(component.as_os_str());
-      }
-      Component::CurDir => {}
-      Component::ParentDir => {
-        ret.pop();
-      }
-      Component::Normal(c) => {
-        ret.push(c);
-      }
-    }
-  }
-  ret
 }

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,0 +1,11 @@
+use std::path::Path;
+
+// Clear the build directory if it exists and create a
+// new build directory if it does not
+pub fn clear_dir(build_dir: &String) {
+  let build_dir_path = Path::new(&build_dir);
+  if build_dir_path.exists() {
+    std::fs::remove_dir_all(build_dir_path).unwrap();
+  }
+  std::fs::create_dir_all(build_dir_path).unwrap();
+}


### PR DESCRIPTION
### Description of changes

Refactor `build_output` and `component_replace` functions so that it addresses a bug that meant not all component import paths would be correctly normalized.