### PR TITLE
Fix javascript output bugs

### DIFF
--- a/src/dom.rs
+++ b/src/dom.rs
@@ -32,14 +32,9 @@ fn create_element(name: &str) -> NodeRef {
   )
 }
 
-pub fn serialize_node_to_string(node: NodeRef) -> String {
-  let mut writer = Vec::new();
-
-  node.serialize(&mut writer).unwrap();
-  let node_str = match str::from_utf8(&writer) {
-    Ok(node_str) => node_str,
-    Err(e) => panic!("Invalid UTF-8 sequence while serializing node: {}", e),
-  };
-
-  String::from(node_str)
+pub fn get_node_text(node: NodeRef) -> String {
+  let node_text = node.as_text().expect(
+    "NEEDS PROPER ERROR HANDLING: `get_node_text` failed to get node text from given node.",
+  );
+  String::from(node_text.borrow().as_str())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ extern crate napi_derive;
 
 use colored::*;
 use component::{component_replace, get_imported_component_paths};
-use dom::{create_and_insert_element, serialize_node_to_string};
+use dom::{create_and_insert_element, get_node_text};
 use file::clear_dir;
 use kuchiki::NodeRef;
 use parse::parse;
@@ -79,7 +79,7 @@ fn build_output(component_path: &Path) -> (NodeRef, String, String) {
     if js_text_node == None {
       continue;
     }
-    js += &serialize_node_to_string(js_text_node.unwrap());
+    js += &get_node_text(js_text_node.unwrap());
     script_node.detach();
   }
 
@@ -87,7 +87,7 @@ fn build_output(component_path: &Path) -> (NodeRef, String, String) {
   for style_tag_match in html.select("style").unwrap() {
     let style_node = style_tag_match.as_node();
     let css_text_node = style_tag_match.as_node().first_child().unwrap();
-    css += &serialize_node_to_string(css_text_node);
+    css += &get_node_text(css_text_node);
     style_node.detach();
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,8 +75,11 @@ fn build_output(entry_dir: &str, component_path: &str) -> (NodeRef, String, Stri
   // Get component JavaScript
   for script_tag_match in html.select("script").unwrap() {
     let script_node = script_tag_match.as_node();
-    let js_text_node = script_node.first_child().unwrap();
-    js += &serialize_node_to_string(js_text_node);
+    let js_text_node = script_node.first_child();
+    if js_text_node == None {
+      continue;
+    }
+    js += &serialize_node_to_string(js_text_node.unwrap());
     script_node.detach();
   }
 


### PR DESCRIPTION
### Description of changes

Fixes two bugs in how JavaScript is processed and output in Delgada source code:

- Empty `<script>` tags (typically in the format `<script src="file.js"></script>`) resulted in an error
- JavaScript source code was previously being serialized under HTML standards resulting in special characters such as `&` being converted to `&amp;`