### PR TITLE
Implement multi-page compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ name = "delgada"
 version = "0.0.1"
 dependencies = [
  "colored",
+ "glob",
  "html5ever",
  "kuchiki",
  "napi",
@@ -163,6 +164,12 @@ dependencies = [
  "libc",
  "wasi",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hermit-abi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ napi-derive = "2.0.0"
 kuchiki = "0.8.1"
 html5ever = "0.25.1"
 colored = "2"
+glob = "0.3.0"
 
 [build-dependencies]
 napi-build = "1.2.0"

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,16 +1,30 @@
-use std::{fs, io, path::Path};
+use colored::*;
+use std::{fs, io, path::Path, process};
 
-// Clear the build directory if it exists and create a
-// new build directory if it does not
-pub fn clear_dir(build_dir: &String) {
-  let build_dir_path = Path::new(&build_dir);
-  if build_dir_path.exists() {
-    std::fs::remove_dir_all(build_dir_path).unwrap();
+pub fn remove_dir_contents(dir: &String) {
+  let dir_path = Path::new(&dir);
+  if dir_path.exists() {
+    std::fs::remove_dir_all(dir_path).unwrap();
   }
-  std::fs::create_dir_all(build_dir_path).unwrap();
+  std::fs::create_dir_all(dir_path).unwrap();
 }
 
-pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+pub fn copy_assets_to_build(assets_path_string: &String, build_dir: &String) {
+  if Path::new(&assets_path_string).exists() {
+    let assets_build_path = format!("{}/assets", build_dir);
+    copy_dir_all(&assets_path_string, &assets_build_path).unwrap_or_else(|err| {
+      println!(
+        "{}: Problem copying assets directory at '{}' to build: {}\n",
+        "Error".red().bold(),
+        assets_path_string,
+        err
+      );
+      process::exit(1);
+    });
+  }
+}
+
+fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
   fs::create_dir_all(&dst)?;
   for entry in fs::read_dir(src)? {
     let entry = entry?;

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{fs, io, path::Path};
 
 // Clear the build directory if it exists and create a
 // new build directory if it does not
@@ -8,4 +8,18 @@ pub fn clear_dir(build_dir: &String) {
     std::fs::remove_dir_all(build_dir_path).unwrap();
   }
   std::fs::create_dir_all(build_dir_path).unwrap();
+}
+
+pub fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<()> {
+  fs::create_dir_all(&dst)?;
+  for entry in fs::read_dir(src)? {
+    let entry = entry?;
+    let ty = entry.file_type()?;
+    if ty.is_dir() {
+      copy_dir_all(entry.path(), dst.as_ref().join(entry.file_name()))?;
+    } else {
+      fs::copy(entry.path(), dst.as_ref().join(entry.file_name()))?;
+    }
+  }
+  Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,67 +4,44 @@ mod component;
 mod dom;
 mod file;
 mod js;
+mod messages;
 mod parse;
 
 #[macro_use]
 extern crate napi_derive;
 
-use colored::*;
 use component::{component_replace, get_imported_component_paths};
 use dom::{create_and_insert_element, get_node_text};
-use file::{clear_dir, copy_dir_all};
+use file::{copy_assets_to_build, remove_dir_contents};
 use glob::glob;
 use kuchiki::NodeRef;
 use parse::parse;
-use std::{collections::BTreeMap, fs, path::Path, process, str, time::Instant};
+use std::{collections::BTreeMap, fs, path::Path, str, time::Instant};
 
 #[napi]
 pub fn compile(entry_dir: String, build_dir: String) {
-  println!(
-    "\n{} source code starting at {}/index.html",
-    "Compiling".green().bold(),
-    entry_dir
-  );
+  messages::compiling(&entry_dir);
   let now = Instant::now();
 
   // Build index/homepage
-  let path_string = format!("{}/index.html", entry_dir);
-  let entry_path = Path::new(&path_string);
+  let assets_path_string = format!("{}/assets", entry_dir);
+  let index_path_string = format!("{}/index.html", entry_dir);
+  let index_path = Path::new(&index_path_string);
+  remove_dir_contents(&build_dir);
+  copy_assets_to_build(&assets_path_string, &build_dir);
+  build_page(index_path, &build_dir);
 
-  // Clear build directory if it exists (or create a new one if it doesn't)
-  clear_dir(&build_dir);
-
-  // If an assets directory exists in the entry directory copy it to the build directory
-  let assets_path = format!("{}/assets", entry_dir);
-  if Path::new(&assets_path).exists() {
-    let assets_build_dir = format!("{}/assets", build_dir);
-    copy_dir_all(&assets_path, &assets_build_dir).unwrap_or_else(|err| {
-      println!(
-        "{}: Problem copying assets directory at '{}' to build: {}\n",
-        "Error".red().bold(),
-        &assets_path,
-        err
-      );
-      process::exit(1);
-    });
-  }
-
-  // Build and write index/homepage output
-  build_page(entry_path, &build_dir);
-
-  // Build pages from pages directory if it exists
-  let path_string = format!("{}/pages", entry_dir);
-  let pages_path = Path::new(&path_string);
+  // Build pages from pages directory (if it exists)
+  let pages_path_string = format!("{}/pages", entry_dir);
+  let pages_path = Path::new(&pages_path_string);
   if pages_path.exists() {
     let pattern = format!("{}/**/index.html", pages_path.to_str().unwrap());
-
-    // Get the entry path for every sub directory in pages
-    for entry_path in glob(&pattern).unwrap().collect::<Vec<_>>() {
-      let entry_path = entry_path.unwrap();
+    for page_path in glob(&pattern).unwrap().collect::<Vec<_>>() {
+      let page_path = page_path.unwrap();
       let build_dir = format!(
         "{}/{}",
         build_dir,
-        entry_path
+        page_path
           .to_str()
           .unwrap()
           .to_string()
@@ -73,40 +50,22 @@ pub fn compile(entry_dir: String, build_dir: String) {
           .strip_suffix("index.html")
           .unwrap()
       );
-
-      // Clear current page directory within build if it exists (or create a new one if it doesn't)
-      clear_dir(&build_dir);
-
-      // If an assets directory exists in the current page directory copy it to the build directory
-      let assets_path = format!(
+      let assets_path_string = format!(
         "{}/assets",
-        entry_path
+        page_path
           .to_str()
           .unwrap()
           .to_string()
           .strip_suffix("/index.html")
           .unwrap()
       );
-      if Path::new(&assets_path).exists() {
-        let assets_build_dir = format!("{}/assets", build_dir);
-        copy_dir_all(&assets_path, &assets_build_dir).unwrap_or_else(|err| {
-          println!(
-            "{}: Problem copying assets directory at '{}' to build: {}\n",
-            "Error".red().bold(),
-            &assets_path,
-            err
-          );
-          process::exit(1);
-        });
-      }
-
-      // Build and write current page output
-      build_page(&entry_path, &build_dir);
+      remove_dir_contents(&build_dir);
+      copy_assets_to_build(&assets_path_string, &build_dir);
+      build_page(&page_path, &build_dir);
     }
   }
 
-  let elapsed = now.elapsed();
-  println!("{} build in {:.2?}\n", "Finished".green().bold(), elapsed);
+  messages::finished(now.elapsed());
 }
 
 fn build_page(component_path: &Path, build_dir: &String) {

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,0 +1,14 @@
+use colored::*;
+use std::{time::Duration};
+
+pub fn compiling(entry_dir: &String) {
+  println!(
+    "{} source code starting at {}/index.html",
+    "Compiling".green().bold(),
+    entry_dir
+  );
+}
+
+pub fn finished(elapsed: Duration) {
+  println!("{} build in {:.2?}\n", "Finished".green().bold(), elapsed);
+}


### PR DESCRIPTION
### Description of changes

Implements multi-page compilation into the Delgada compiler using the `pages` directory convention. If a `pages` directory is found all sub-directories with an `index.html` file will be compiled as a distinct page of the website.

Also implements automatic copying of `assets` directories into the build folder.