### PR TITLE
Implement component props and template syntax

### DIFF
--- a/src/component.rs
+++ b/src/component.rs
@@ -85,8 +85,7 @@ fn remove_whitespace(s: &mut String) {
 }
 
 pub fn get_component_props(component: &NodeRef, props_list: &mut BTreeMap<String, String>) {
-  let data = component.data().to_owned();
-  match data {
+  match component.data() {
     NodeData::Element(component_data) => {
       let props = component_data.attributes.borrow().to_owned().map;
       for (prop_name, prop_value) in props {
@@ -109,13 +108,13 @@ pub fn replace_props(html: &NodeRef, component_props: &BTreeMap<String, String>)
       match node.data() {
         NodeData::Element(element_data) => {
           let mut attrs = element_data.attributes.borrow_mut();
-          let mut replace_values = BTreeMap::new();
+          let mut attr_to_prop_mapping = BTreeMap::new();
           for (attr_name, attr_value) in attrs.to_owned().map {
             if attr_value.value.contains(&pattern) {
-              replace_values.insert(attr_name.local, prop_value.to_string());
+              attr_to_prop_mapping.insert(attr_name.local, prop_value.to_string());
             }
           }
-          for (attr_name, prop_value) in replace_values {
+          for (attr_name, prop_value) in attr_to_prop_mapping {
             attrs.remove(&attr_name);
             attrs.insert(&attr_name, prop_value);
           }

--- a/src/component.rs
+++ b/src/component.rs
@@ -120,7 +120,6 @@ pub fn replace_props(html: &NodeRef, component_props: &BTreeMap<String, String>)
             NodeData::Text(element_text) => {
               let text = element_text.borrow().to_owned();
               let text = text.replace(&pattern, &prop_value);
-              println!("text: {}", text);
               let text_parent_node = text_node.parent().unwrap();
               text_parent_node.append(NodeRef::new_text(text));
               text_node.detach();

--- a/src/component.rs
+++ b/src/component.rs
@@ -93,12 +93,12 @@ pub fn get_component_props(component: &NodeRef, props_list: &mut BTreeMap<String
         props_list.insert(prop_name.local.to_string(), prop_value.value.to_string());
       }
     }
-    NodeData::Comment(_) => println!("\ncomment\n"),
-    NodeData::Doctype(_) => println!("\ndoctype\n"),
-    NodeData::Document(_) => println!("\ndocument\n"),
-    NodeData::DocumentFragment => println!("\ndoc fragment\n"),
-    NodeData::ProcessingInstruction(_) => println!("\nprocessing instruction\n"),
-    NodeData::Text(_) => println!("\ntext\n"),
+    NodeData::Comment(_) => (),
+    NodeData::Doctype(_) => (),
+    NodeData::Document(_) => (),
+    NodeData::DocumentFragment => (),
+    NodeData::ProcessingInstruction(_) => (),
+    NodeData::Text(_) => (),
   }
 }
 
@@ -111,12 +111,6 @@ pub fn replace_props(html: &NodeRef, component_props: &BTreeMap<String, String>)
         if text.borrow().as_str().contains(&pattern) {
           let data = text_node.data().to_owned();
           match data {
-            NodeData::Element(_) => println!("\nelement\n"),
-            NodeData::Comment(_) => println!("\ncomment\n"),
-            NodeData::Doctype(_) => println!("\ndoctype\n"),
-            NodeData::Document(_) => println!("\ndocument\n"),
-            NodeData::DocumentFragment => println!("\ndoc fragment\n"),
-            NodeData::ProcessingInstruction(_) => println!("\nprocessing instruction\n"),
             NodeData::Text(element_text) => {
               let text = element_text.borrow().to_owned();
               let text = text.replace(&pattern, &prop_value);
@@ -124,6 +118,12 @@ pub fn replace_props(html: &NodeRef, component_props: &BTreeMap<String, String>)
               text_parent_node.append(NodeRef::new_text(text));
               text_node.detach();
             }
+            NodeData::Comment(_) => (),
+            NodeData::Element(_) => (),
+            NodeData::Doctype(_) => (),
+            NodeData::Document(_) => (),
+            NodeData::DocumentFragment => (),
+            NodeData::ProcessingInstruction(_) => (),
           }
         }
       }


### PR DESCRIPTION
### Description of changes

Implements basic component props and template syntax into the Delgada compiler. 

An example of the syntax:

```html
// File: hello-link.html

<a href="{link}">Hello {name}</a>
```

```html
// File: index.html

<!--
  import './hello-link.html'
-->

<hello-link 
  name="world"
  link="https://example.com"
></hello-link>
```