### PR TITLE
Update output build paths

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,19 @@ fn build_page(component_path: &Path, build_dir: &String) {
     let css_build_path = format!("{}/index.css", build_dir);
     fs::write(css_build_path, css).expect("Unable to write file");
 
+    let build_dir_list: Vec<&str> = build_dir.split("/").collect();
+    let output_build_path: String;
+    if build_dir_list[0] == "." {
+      output_build_path = build_dir_list[2..].join("/");
+    } else {
+      output_build_path = build_dir_list[1..].join("/");
+    }
+
+    let output_build_path = format!("{}index.css", output_build_path);
+
     // Add link tag referencing index.css within html
     let mut attrs = BTreeMap::<&str, &str>::new();
-    attrs.insert("href", "index.css");
+    attrs.insert("href", &output_build_path);
     attrs.insert("rel", "stylesheet");
     create_and_insert_element(&html, "head", "link", attrs);
   }
@@ -92,9 +102,19 @@ fn build_page(component_path: &Path, build_dir: &String) {
     let js = js::post_process(js);
     fs::write(js_build_path, js).expect("Unable to write file");
 
+    let build_dir_list: Vec<&str> = build_dir.split("/").collect();
+    let output_build_path: String;
+    if build_dir_list[0] == "." {
+      output_build_path = build_dir_list[2..].join("/");
+    } else {
+      output_build_path = build_dir_list[1..].join("/");
+    }
+
+    let output_build_path = format!("{}index.js", output_build_path);
+
     // Add script tag referencing index.js within html
     let mut attrs = BTreeMap::<&str, &str>::new();
-    attrs.insert("src", "index.js");
+    attrs.insert("src", &output_build_path);
     attrs.insert("type", "module");
     create_and_insert_element(&html, "head", "script", attrs);
   }


### PR DESCRIPTION
### Description of changes

Update output build paths that will be used in the inserted link/script tags of built CSS and JS files. 

This resolves a bug where the dev server will locate all files from the given root, instead of the current folder where HTML, CSS, and JS files live.

For example, associated CSS and JS files referenced in an HTML file located at `build/about/index.html` (where `build` is the root of the dev server) previously had file paths like so:

```html 
<link href="index.css" rel="stylesheet">
<script src="index.js" type="module"></script>
```

This resulted in an error because the dev server would try to locate these files at `build/index.css` and `build/index.js` (instead of `build/about/index.css` and `build/about/index.js`).

Now all associated CSS and JS files will have more complete file paths that take into account this behavior, like so:

 ```html 
<link href="about/index.css" rel="stylesheet">
<script src="about/index.js" type="module"></script>
```