### PR TITLE
Update build output structure

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -9,6 +9,14 @@ pub fn remove_dir_contents(dir: &String) {
   std::fs::create_dir_all(dir_path).unwrap();
 }
 
+// Given a directory path, create that directory if it doesn't exist.
+pub fn create_dir(dir: &String) {
+  let dir_path = Path::new(&dir);
+  if !dir_path.exists() {
+    std::fs::create_dir_all(dir_path).unwrap();
+  }
+}
+
 pub fn copy_assets_to_build(assets_path_string: &String, build_dir: &String) {
   if Path::new(&assets_path_string).exists() {
     let assets_build_path = format!("{}/assets", build_dir);


### PR DESCRIPTION
### Description of changes

This PR flattens the file structure of the Delgada compiler `build` directory output. The goal of this change is to better accommodate how static file routing works on services like Cloudflare Pages.

As an example, the compiler previously would output a `build` directory that looked something like this:

```
build/
├─ about/
│  ├─ index.css
│  ├─ index.html
│  ├─ index.js
├─ writing/
│  ├─ post-1/
│  │  ├─ index.css
│  │  ├─ index.html
│  │  ├─ index.js
├─ index.css
├─ index.html
├─ index.js
```

This PR will now make the same output look like this:

```
build/
├─ writing/
│  ├─ post-1.css
│  ├─ post-1.html
│  ├─ post-1.js
├─ about.css
├─ about.html
├─ about.js
├─ index.css
├─ index.html
├─ index.js
```