### PR TITLE
Add static file serving

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -1,24 +1,22 @@
 import fs from 'fs';
 import path from 'path';
-import { delDir, createDir, copyDir } from '../core/dir.js';
+import { delDir, createDir, copyDirContents } from '../core/dir.js';
 import { buildPage } from '../core/buildPage.js';
 import { getPageTemplate } from '../core/pageTemplate.js';
 
-export async function build(buildDirectory: string) {
+export async function build() {
   const startTime = performance.now();
-  const publicDirectory = 'public';
+  const cwd = process.cwd();
+  const buildDirectory = `${cwd}/build`;
+  const publicDirectory = `${cwd}/public`;
+  const wcDirectory = `${cwd}/src/components/wc`;
+  const pagesDirectory = `${cwd}/src/pages`;
 
-  // Clear the build directory if it exists and
-  // create a new build directory if it does not
   delDir(buildDirectory);
   createDir(buildDirectory);
+  copyDirContents(publicDirectory, buildDirectory);
+  copyDirContents(wcDirectory, buildDirectory);
 
-  // Copy the public and web components directories
-  // to the build directory if they exist
-  copyDir(publicDirectory, buildDirectory);
-  copyDir('src/components/wc', buildDirectory);
-
-  const pagesDirectory = `${process.cwd()}/src/pages`;
   await buildPages(buildDirectory, pagesDirectory);
 
   const buildTime = (performance.now() - startTime).toFixed(3);
@@ -56,7 +54,7 @@ async function buildPages(buildDirectory: string, pagesDirectory: string) {
       }
 
       console.log(`Building ${pageName} page...`);
-      buildPage(
+      await buildPage(
         buildDirectory,
         currFilePath,
         pageName,

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -5,8 +5,7 @@ async function main() {
   const command = process.argv[2];
   switch (command) {
     case 'build':
-      let buildDirectoryPath = process.argv[3] ? process.argv[3] : './build';
-      build(buildDirectoryPath);
+      await build();
       break;
     default:
       console.error('Invalid command.');

--- a/src/core/buildPage.ts
+++ b/src/core/buildPage.ts
@@ -2,7 +2,7 @@ import fs from 'fs';
 import { marked } from 'marked';
 import { writeFile } from './dir.js';
 import { addStyles } from './styles.js';
-import { addWebComponentScriptTags } from './webComponents.js';
+import { addWebComponents } from './webComponents.js';
 import { parseMarkdownMetadata } from './markdown.js';
 
 export async function buildPage(
@@ -55,6 +55,6 @@ export async function buildPage(
     buildDirectory,
     pageName
   );
-  pageOutput = addWebComponentScriptTags(pageOutput);
+  pageOutput = addWebComponents(pageOutput);
   writeFile(`${buildDirectory}/${pageName}.html`, pageOutput);
 }

--- a/src/core/dir.ts
+++ b/src/core/dir.ts
@@ -55,6 +55,23 @@ export function copyDir(source: string, target: string) {
   }
 }
 
+export function copyDirContents(source: string, target: string) {
+  if (fs.existsSync(source)) {
+    let files = [];
+    if (fs.lstatSync(source).isDirectory()) {
+      files = fs.readdirSync(source);
+      files.forEach(function (file) {
+        const curSource = path.join(source, file);
+        if (fs.lstatSync(curSource).isDirectory()) {
+          copyDir(curSource, target);
+        } else {
+          copyFile(curSource, target);
+        }
+      });
+    }
+  }
+}
+
 export function copyFile(source: string, target: string) {
   let targetFile = target;
 

--- a/src/core/webComponents.ts
+++ b/src/core/webComponents.ts
@@ -1,13 +1,16 @@
 import fs from 'fs';
+import path from 'path';
 
-export function addWebComponentScriptTags(output: string) {
-  const wcFiles = fs.readdirSync('build/wc');
-  for (const file of wcFiles) {
-    const wcName = file.replace('.js', '');
-    if (output.includes(`<${wcName}>`) && output.includes(`</${wcName}>`)) {
-      // TODO: Edge case when script tag is placed in nested dir (e.g. `../../wc/file.js`)
-      const wcScript = `<script type="module" src="./wc/${file}"></script>`;
-      output = output.replace(`</head>`, `${wcScript}\n</head>`);
+export function addWebComponents(output: string) {
+  const buildFiles = fs.readdirSync('build');
+  for (const file of buildFiles) {
+    const fileExtension = path.extname(file);
+    if (fileExtension === '.js') {
+      const wcName = file.replace('.js', '');
+      if (output.includes(`<${wcName}>`) && output.includes(`</${wcName}>`)) {
+        const wcScript = `<script type="module" src="/${file}"></script>`;
+        output = output.replace(`</head>`, `${wcScript}\n</head>`);
+      }
     }
   }
   return output;


### PR DESCRIPTION
### Description of changes

Implement static file serving at the root of the build path.

It means all files placed in the `public` directory can be referenced like the below (instead of a relative reference):

```html
<!-- New way -->
<img src="/my-image.png" alt="Some alt text" />

<!-- Old way -->
<img src="./public/my-image.png" alt="Some alt text" />
```

This PR also implements the same sort of logic for web component files, which makes the internal implementation for adding script tags that reference WC files easier.