### PR TITLE
Add `scripts` config to metadata object

### DIFF
--- a/src/core/buildPage.ts
+++ b/src/core/buildPage.ts
@@ -3,6 +3,7 @@ import { marked } from 'marked';
 import { writeFile } from './dir.js';
 import { addStyles } from './styles.js';
 import { addWebComponents } from './webComponents.js';
+import { addScripts } from './scripts.js';
 import { parseMarkdownMetadata } from './markdown.js';
 
 export async function buildPage(
@@ -56,5 +57,6 @@ export async function buildPage(
     pageName
   );
   pageOutput = addWebComponents(pageOutput);
+  pageOutput = addScripts(pageOutput, pageMetadata.scripts);
   writeFile(`${buildDirectory}/${pageName}.html`, pageOutput);
 }

--- a/src/core/scripts.ts
+++ b/src/core/scripts.ts
@@ -1,0 +1,9 @@
+export function addScripts(output: string, scripts: string[]) {
+  if (scripts) {
+    for (const file of scripts) {
+      const scriptTag = `<script type="module" src="/${file}"></script>`;
+      output = output.replace(`</head>`, `${scriptTag}\n</head>`);
+    }
+  }
+  return output;
+}


### PR DESCRIPTION
### Description of changes

Add a `scripts` config to the metadata object. This implements the ability to define scripts that will run on a given page.

To use this feature, add any scripts to the `public` directory.

Then on a given javascript or markdown page, add a `scripts` config option and pass it an array of the script files that should be run on that page.

```js
export const metadata = {
  scripts: ['script.js', 'another-script.js']
}
```

For each script in the array, a script tag will be added to the final page output in the following format.

```html
<script type="module" src="/script.js"></script>
<script type="module" src="/another-script.js"></script>
```