### PR TITLE
Update naming conventions

### DIFF
--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -42,10 +42,10 @@ async function buildPages(buildDirectory: string, pagesDirectory: string) {
       let pageName = '';
       switch (fileExtension) {
         case '.js':
-          pageName = file.replace('.js', '');
+          pageName = file.replace('.js', '').toLowerCase();
           break;
         case '.md':
-          pageName = file.replace('.md', '');
+          pageName = file.replace('.md', '').toLowerCase();
           break;
         default:
           throw new Error(

--- a/src/cli/build.ts
+++ b/src/cli/build.ts
@@ -9,13 +9,13 @@ export async function build() {
   const cwd = process.cwd();
   const buildDirectory = `${cwd}/build`;
   const publicDirectory = `${cwd}/public`;
-  const wcDirectory = `${cwd}/src/components/wc`;
+  const islandsDirectory = `${cwd}/src/components/islands`;
   const pagesDirectory = `${cwd}/src/pages`;
 
   delDir(buildDirectory);
   createDir(buildDirectory);
   copyDirContents(publicDirectory, buildDirectory);
-  copyDirContents(wcDirectory, buildDirectory);
+  copyDirContents(islandsDirectory, buildDirectory);
 
   await buildPages(buildDirectory, pagesDirectory);
 

--- a/src/core/webComponents.ts
+++ b/src/core/webComponents.ts
@@ -6,8 +6,13 @@ export function addWebComponents(output: string) {
   for (const file of buildFiles) {
     const fileExtension = path.extname(file);
     if (fileExtension === '.js') {
-      const wcName = file.replace('.js', '');
-      // Developer note: When checking for an opening tag, we leave out the 
+      // Turn a file (WebComponent.js) into its name `web-component`
+      const wcName = file
+        .replace('.js', '')
+        .split(/(?=[A-Z])/)
+        .join('-')
+        .toLowerCase();
+      // Developer note: When checking for an opening tag, we leave out the
       // closing alligator (`>`) because the web component might include attributes.
       if (output.includes(`<${wcName}`) && output.includes(`</${wcName}>`)) {
         const wcScript = `<script type="module" src="/${file}"></script>`;


### PR DESCRIPTION
### Description of changes

Add some small (opinionated) naming convention changes

- All web components must be placed in a `src/components/islands` directory now
- All web component files must be PascalCase (i.e. `CounterButton.js`)
- All static components in the `src/pages` directory can be optionally PascalCase